### PR TITLE
Add mode setting to navigation keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Tab-based Searching**: Easily switch between different search modes, each represented by a tab.
 - **Integration with Telescope**: Leverages the power of the Telescope plugin for versatile searching.
 - **Customizable Tabs**: Configure the available tabs according to your preferences. (coming soon)
-- **keybindings for switching tabs**: switch tabs by configurable keys (coming soon)
+- **keybindings for switching tabs**: switch tabs by configurable keys
 
 ## Installation
 
@@ -95,16 +95,31 @@ require("search").setup({
 })
 ```
 
+### Customizing key bindings
+Simple rebind, will bind the the keys in both normal mode and insert mode.
+```lua
+  mappings = {
+    next = "<Tab>",
+    prev = "<S-Tab>"
+  }
+```
+You can also bind keys in specific modes by supplying a list of key-mode pairs. The following would bind H and L to previous and next in normal mode
+in addition to binding tab and shift+tab like in the example above.
+```lua
+  mappings = {
+    next = { { "L", "n" }, { "<Tab>", "n" }, { "<Tab>", "i" } },
+    prev = { { "H", "n" }, { "<S-Tab>", "n" }, { "<S-Tab>", "i" } }
+  }
+```
+
 ### Tab Collections
 If you want to group certain pickers together into separate search windows you can use the collections keyword:
 
 ```lua
 local builtin = require('telescope.builtin')
 require("search").setup({
-  tabs = {
-    initial_tab = 1,
-    tabs = { ... } -- As shown above
-  },
+  initial_tab = 1,
+  tabs = { ... }, -- As shown above
   collections = {
     -- Here the "git" collection is defined. It follows the same configuraton layout as tabs.
     git = {

--- a/lua/search/settings.lua
+++ b/lua/search/settings.lua
@@ -5,8 +5,8 @@ M.default_initial_tab = 1
 M.initialized = false
 
 M.default_keys = {
-	next = "<Tab>",
-	prev = "<S-Tab>",
+	next = { { "<Tab>", "n" }, { "<Tab>", "i" } },
+	prev = { { "<S-Tab>", "n" }, { "<S-Tab>", "i" } },
 }
 
 M.keys = vim.deepcopy(M.default_keys)

--- a/lua/search/util.lua
+++ b/lua/search/util.lua
@@ -38,10 +38,13 @@ M.set_keymap = function()
 	local opts = { noremap = true, silent = true }
 	local cmd = "<cmd>lua require('search').next_tab()<CR>"
 	local cmd_p = "<cmd>lua require('search').previous_tab()<CR>"
-	vim.api.nvim_buf_set_keymap(0, 'n', settings.keys.next, cmd, opts)
-	vim.api.nvim_buf_set_keymap(0, 'i', settings.keys.next, cmd, opts)
-	vim.api.nvim_buf_set_keymap(0, 'n', settings.keys.prev, cmd_p, opts)
-	vim.api.nvim_buf_set_keymap(0, 'i', settings.keys.prev, cmd_p, opts)
+
+	for _, value in ipairs(settings.keys.next) do
+		vim.api.nvim_buf_set_keymap(0, value[2], value[1], cmd, opts)
+	end
+	for _, value in ipairs(settings.keys.prev) do
+		vim.api.nvim_buf_set_keymap(0, value[2], value[1], cmd_p, opts)
+	end
 end
 
 --- switches to the next available tab

--- a/lua/search/util.lua
+++ b/lua/search/util.lua
@@ -39,13 +39,21 @@ M.set_keymap = function()
 	local cmd = "<cmd>lua require('search').next_tab()<CR>"
 	local cmd_p = "<cmd>lua require('search').previous_tab()<CR>"
 
-	for _, value in ipairs(settings.keys.next) do
-		vim.api.nvim_buf_set_keymap(0, value[2], value[1], cmd, opts)
-	end
-	for _, value in ipairs(settings.keys.prev) do
-		vim.api.nvim_buf_set_keymap(0, value[2], value[1], cmd_p, opts)
-	end
-end
+
+  local function set_keymap(keymap, cmd)
+    if type(keymap) == "string" then
+      vim.api.nvim_buf_set_keymap(0, 'n', keymap, cmd, opts)
+      vim.api.nvim_buf_set_keymap(0, 'i', keymap, cmd, opts)
+    else
+      for _, value in ipairs(keymap) do
+        vim.api.nvim_buf_set_keymap(0, value[2], value[1], cmd, opts)
+      end
+    end
+  end
+
+  set_keymap(settings.keys.next, cmd)
+  set_keymap(settings.keys.prev, cmd_p)
+  end
 
 --- switches to the next available tab
 --- @return Tab # the next available tab


### PR DESCRIPTION
> Rework the mappings option to take a list of key remaps. Allows using regular keys like hjkl to navigate tabs in normal mode.

This a suggestion for how a feature resolving #19 could be implemented. It does change some behavior slightly though.
The following has changed, if a user performs the following steps:
 1. Open a new search instance, and get put into insert mode.
 2. Press esc to enter normal mode inside telescope.
 3. Press tab to to the next pane.

Currently this will put the user into insert mode in the next pane. With the PR change the user will remain in normal mode and will have to enter insert mode manually.
 
 I think the internal logic here is sound, but there could be a nicer way to do the configuration interface.